### PR TITLE
Update normalizeValue method in Colours Field

### DIFF
--- a/src/fields/Colours.php
+++ b/src/fields/Colours.php
@@ -91,7 +91,7 @@ class Colours extends BaseOptionsField
             $value = $this->defaultValue();
         }
 
-        return $value;
+        return parent::normalizeValue($value, $element);
     }
 
     /**


### PR DESCRIPTION
Validation of options field expect data to be an instance of either a MultiOptionsFieldData or SingleOptionFieldData.

Because you're setting a custom defaultValue, you never normalize the value according to the parent method and an exception is throw in PHP 7.2.

Fixes #18