### PR TITLE
Craft 4 compatible 'Button Box' plugin with working fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Button Box - a plugin for Craft CMS 3.x
+# Button Box - a plugin for Craft CMS 4.x
 
 A set of utility field types:
 
@@ -19,7 +19,7 @@ For details of how to use and install this plugin please see the [docs](http://p
 
 ## Requirements
 
-This plugin requires Craft CMS 3.0.0 RC or later.
+This plugin requires Craft CMS 4.0.0 or later.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,9 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^3.7.0",
-        "verbb/base": "^1.0.2"
+        "craftcms/cms": "^4.0.0",
+        "verbb/base": "^2.0.0",
+        "php": "^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/ButtonBox.php
+++ b/src/ButtonBox.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Button Box plugin for Craft CMS 3.x
+ * Button Box plugin for Craft CMS 4.x
  *
  * Button Box
  *
@@ -47,7 +47,7 @@ class ButtonBox extends Plugin
      */
     public static $plugin;
 
-    public $schemaVersion = '2.0.0';
+    public string $schemaVersion = '2.0.0';
 
     // Public Methods
     // =========================================================================
@@ -70,7 +70,7 @@ class ButtonBox extends Plugin
 
         // Register our fields
         Event::on(
-            Fields::className(),
+            Fields::class,
             Fields::EVENT_REGISTER_FIELD_TYPES,
             function (RegisterComponentTypesEvent $event) {
                 $event->types[] = StarsField::class;
@@ -84,7 +84,7 @@ class ButtonBox extends Plugin
 
         // Do something after we're installed
         Event::on(
-            Plugins::className(),
+            Plugins::class,
             Plugins::EVENT_AFTER_INSTALL_PLUGIN,
             function (PluginEvent $event) {
                 if ($event->plugin === $this) {

--- a/src/assetbundles/buttonbox/ButtonBoxAsset.php
+++ b/src/assetbundles/buttonbox/ButtonBoxAsset.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ButtonBox plugin for Craft CMS 3.x
+ * ButtonBox plugin for Craft CMS 4.x
  *
  * ButtonBox
  *

--- a/src/fields/Buttons.php
+++ b/src/fields/Buttons.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ButtonBox plugin for Craft CMS 3.x
+ * ButtonBox plugin for Craft CMS 4.x
  *
  * ButtonBox
  *
@@ -10,6 +10,7 @@
 
 namespace verbb\buttonbox\fields;
 
+use craft\helpers\Cp;
 use verbb\buttonbox\ButtonBox as ButtonBoxPlugin;
 use verbb\buttonbox\assetbundles\buttonbox\ButtonBoxAsset;
 
@@ -41,7 +42,7 @@ class Buttons extends BaseOptionsField
     
     public $displayAsGraphic;
     public $displayFullwidth;
-    public $options;
+    public array $options;
 
     /**
      * Returns the display name of this class.
@@ -61,7 +62,7 @@ class Buttons extends BaseOptionsField
      *
      * @return array
      */
-    public function rules()
+    public function rules(): array
     {
         $rules = parent::rules();
         return $rules;
@@ -88,13 +89,13 @@ class Buttons extends BaseOptionsField
      *
      * @return mixed The prepared field value
      */
-    public function normalizeValue($value, ElementInterface $element = null)
+    public function normalizeValue(mixed $value, ?\craft\base\ElementInterface $element = null): mixed
     {
         if ( !$value )
         {
             $value = $this->defaultValue();
         }
-        
+
         if ($value instanceof SingleOptionFieldData) {
             $value = $value->value;
         }
@@ -103,7 +104,7 @@ class Buttons extends BaseOptionsField
         $selectedValues = (array)$value;
 
         $value = reset($selectedValues) ?: null;
-        $label = $this->optionLabel($value);
+        $label = $this->optionsSettingLabel();
         $value = new SingleOptionFieldData($label, $value, true);
 
         $options = [];
@@ -132,7 +133,7 @@ class Buttons extends BaseOptionsField
      *
      * @return null|false `false` in the event that the method is sure that no elements are going to be found.
      */
-    public function serializeValue($value, ElementInterface $element = null)
+    public function serializeValue(mixed $value, ?\craft\base\ElementInterface $element = null): mixed
     {
         return parent::serializeValue($value, $element);
     }
@@ -142,7 +143,7 @@ class Buttons extends BaseOptionsField
      *
      * @return string|null
      */
-    public function getSettingsHtml()
+    public function getSettingsHtml(): ?string
     {
         $options = $this->translatedOptions();
 
@@ -159,66 +160,63 @@ class Buttons extends BaseOptionsField
             ];
         }
 
-        $table = Craft::$app->getView()->renderTemplateMacro('_includes/forms', 'editableTableField', array(
-            array(
-                'label'        => $this->optionsSettingLabel(),
-                'instructions' => Craft::t('buttonbox', 'Image urls can be relative e.g. /images/align-left.png'),
-                'id'           => 'options',
-                'name'         => 'options',
-                'addRowLabel'  => Craft::t('buttonbox', 'Add an option'),
-                'cols'         => array(
-                    'label' => array(
-                    'heading'      => Craft::t('buttonbox', 'Option Label'),
-                    'type'         => 'singleline',
+        $table = Cp::editableTableFieldHtml(array(
+            'label' => $this->optionsSettingLabel(),
+            'instructions' => Craft::t('buttonbox', 'Image urls can be relative e.g. /images/align-left.png'),
+            'id' => 'options',
+            'name' => 'options',
+            'addRowLabel' => Craft::t('buttonbox', 'Add an option'),
+            'allowAdd' => true,
+            'allowReorder' => true,
+            'allowDelete' => true,
+            'cols' => array(
+                'label' => array(
+                    'heading' => Craft::t('buttonbox', 'Option Label'),
+                    'type' => 'singleline',
                     'autopopulate' => 'value'
-                    ),
+                ),
                 'showLabel' => array(
-                        'heading'      => Craft::t('buttonbox', 'Show Label?'),
-                        'type'         => 'checkbox',
-                        'class'        => 'thin'
-                        ),
+                    'heading' => Craft::t('buttonbox', 'Show Label?'),
+                    'type' => 'checkbox',
+                    'class' => 'thin'
+                ),
                 'value' => array(
-                        'heading'      => Craft::t('buttonbox', 'Value'),
-                        'type'         => 'singleline',
-                        'class'        => 'code'
-                        ),
+                    'heading' => Craft::t('buttonbox', 'Value'),
+                    'type' => 'singleline',
+                    'class' => 'code'
+                ),
                 'imageUrl' => array(
-                        'heading'      => Craft::t('buttonbox', 'Image URL'),
-                        'type'         => 'singleline'
-                        ),
+                    'heading' => Craft::t('buttonbox', 'Image URL'),
+                    'type' => 'singleline'
+                ),
                 'default' => array(
-                        'heading'      => Craft::t('buttonbox', 'Default?'),
-                        'type'         => 'checkbox',
-                        'class'        => 'thin'
-                        ),
-                    ),
-                'rows' => $options
-                )
-            ));
+                    'heading' => Craft::t('buttonbox', 'Default?'),
+                    'type' => 'checkbox',
+                    'class' => 'thin'
+                ),
+            ),
+            'rows' => $options
+        ));
 
-        $displayAsGraphic = Craft::$app->getView()->renderTemplateMacro('_includes/forms', 'checkboxField', array(
-            array(
-                'label' => Craft::t('buttonbox', 'Display as graphic'),
-                'instructions' => Craft::t('buttonbox', 'This will take the height restrictions off the buttons to allow for larger images.'),
-                'id' => 'displayAsGraphic',
-                'name' => 'displayAsGraphic',
-                'class' => 'displayAsGraphic',
-                'value' => 1,
-                'checked' => $this->displayAsGraphic
-                )
-            ));
+        $displayAsGraphic = Cp::checkboxFieldHtml(array(
+            'checkboxLabel' => Craft::t('buttonbox', 'Display as graphic'),
+            'instructions' => Craft::t('buttonbox', 'This will take the height restrictions off the buttons to allow for larger images.'),
+            'id' => 'displayAsGraphic',
+            'name' => 'displayAsGraphic',
+            'class' => 'displayAsGraphic',
+            'value' => 1,
+            'checked' => $this->displayAsGraphic
+        ));
 
-        $displayFullwidth = Craft::$app->getView()->renderTemplateMacro('_includes/forms', 'checkboxField', array(
-            array(
-                'label' => Craft::t('buttonbox', 'Display full width'),
-                'instructions' => Craft::t('buttonbox', 'Allow the button group to be fullwidth, useful for allowing larger graphics to be more responsive.'),
-                'id' => 'displayFullwidth',
-                'name' => 'displayFullwidth',
-                'class' => 'displayFullwidth',
-                'value' => 1,
-                'checked' => $this->displayFullwidth
-                )
-            ));
+        $displayFullwidth = Cp::checkboxFieldHtml(array(
+            'checkboxLabel' => Craft::t('buttonbox', 'Display full width'),
+            'instructions' => Craft::t('buttonbox', 'Allow the button group to be fullwidth, useful for allowing larger graphics to be more responsive.'),
+            'id' => 'displayFullwidth',
+            'name' => 'displayFullwidth',
+            'class' => 'displayFullwidth',
+            'value' => 1,
+            'checked' => $this->displayFullwidth
+        ));
 
         return $displayAsGraphic . $displayFullwidth . $table;
 
@@ -231,7 +229,7 @@ class Buttons extends BaseOptionsField
      *
      * @return string The input HTML.
      */
-    public function getInputHtml($value, ElementInterface $element = null): string
+    public function getInputHtml(mixed $value, ?\craft\base\ElementInterface $element = null): string
     {
         $name = $this->handle;
         $options = $this->translatedOptions();
@@ -265,10 +263,10 @@ class Buttons extends BaseOptionsField
 
     /**
      * Override this method to return custom default value
-     * 
-     * @return string 
+     *
+     * @return array|string|null
      */
-    protected function defaultValue()
+    protected function defaultValue(): array|string|null
     {
 
         $options = $this->translatedOptions();

--- a/src/fields/Colours.php
+++ b/src/fields/Colours.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ButtonBox plugin for Craft CMS 3.x
+ * ButtonBox plugin for Craft CMS 4.x
  *
  * ButtonBox
  *
@@ -10,6 +10,7 @@
 
 namespace verbb\buttonbox\fields;
 
+use craft\helpers\Cp;
 use verbb\buttonbox\ButtonBox as ButtonBoxPlugin;
 use verbb\buttonbox\assetbundles\buttonbox\ButtonBoxAsset;
 
@@ -39,7 +40,7 @@ class Colours extends BaseOptionsField
     // Static Methods
     // =========================================================================
     
-    public $options;
+    public array $options;
 
     /**
      * Returns the display name of this class.
@@ -59,7 +60,7 @@ class Colours extends BaseOptionsField
      *
      * @return array
      */
-    public function rules()
+    public function rules(): array
     {
         $rules = parent::rules();
         return $rules;
@@ -86,22 +87,24 @@ class Colours extends BaseOptionsField
      *
      * @return mixed The prepared field value
      */
-    public function normalizeValue($value, ElementInterface $element = null)
+    public function normalizeValue(mixed $value, ?\craft\base\ElementInterface $element = null): mixed
     {
         if ( !$value )
         {
             $value = $this->defaultValue();
         }
-        
+
         if ($value instanceof SingleOptionFieldData) {
             $value = $value->value;
         }
 
         // Normalize to an array
-        $selectedValues = (array)$value;
+        $selectedValues = [];
+        foreach ((array)$value as $val) {
+            $selectedValues[] = (string)$val;
+        }
 
-        $value = reset($selectedValues) ?: null;
-        $label = $this->optionLabel($value);
+        $label = $this->optionsSettingLabel();
         $value = new SingleOptionFieldData($label, $value, true);
 
         $options = [];
@@ -130,7 +133,7 @@ class Colours extends BaseOptionsField
      *
      * @return null|false `false` in the event that the method is sure that no elements are going to be found.
      */
-    public function serializeValue($value, ElementInterface $element = null)
+    public function serializeValue(mixed $value, ?\craft\base\ElementInterface $element = null): mixed
     {
         return parent::serializeValue($value, $element);
     }
@@ -140,7 +143,7 @@ class Colours extends BaseOptionsField
      *
      * @return string|null
      */
-    public function getSettingsHtml()
+    public function getSettingsHtml(): ?string
     {
         $options = $this->translatedOptions();
 
@@ -156,37 +159,38 @@ class Colours extends BaseOptionsField
             );
         }
 
-        return Craft::$app->getView()->renderTemplateMacro('_includes/forms', 'editableTableField', array(
-            array(
-                'label'        => $this->optionsSettingLabel(),
-                'instructions' => Craft::t('buttonbox', 'Define the available options.'),
-                'id'           => 'options',
-                'name'         => 'options',
-                'addRowLabel'  => Craft::t('buttonbox', 'Add an option'),
-                'cols'         => array(
-                    'label' => array(
-                        'heading'      => Craft::t('buttonbox', 'Option Label'),
-                        'type'         => 'singleline',
-                        'autopopulate' => 'value'
-                    ),
-                    'value' => array(
-                        'heading'      => Craft::t('buttonbox', 'Value'),
-                        'type'         => 'singleline',
-                        'class'        => 'code'
-                    ),
-                    'cssColour' => array(
-                        'heading'      => Craft::t('buttonbox', 'Valid CSS Colour'),
-                        'type'         => 'singleline',
-                        'class'        => 'code'
-                    ),
-                    'default' => array(
-                        'heading'      => Craft::t('buttonbox', 'Default?'),
-                        'type'         => 'checkbox',
-                        'class'        => 'thin'
-                    ),
+        return Cp::editableTableFieldHtml(array(
+            'label' => $this->optionsSettingLabel(),
+            'instructions' => Craft::t('buttonbox', 'Define the available options.'),
+            'id' => 'options',
+            'name' => 'options',
+            'allowAdd' => true,
+            'allowReorder' => true,
+            'allowDelete' => true,
+            'addRowLabel' => Craft::t('buttonbox', 'Add an option'),
+            'cols' => array(
+                'label' => array(
+                    'heading' => Craft::t('buttonbox', 'Option Label'),
+                    'type' => 'singleline',
+                    'autopopulate' => 'value'
                 ),
-                'rows' => $options
-            )
+                'value' => array(
+                    'heading' => Craft::t('buttonbox', 'Value'),
+                    'type' => 'singleline',
+                    'class' => 'code'
+                ),
+                'cssColour' => array(
+                    'heading' => Craft::t('buttonbox', 'Valid CSS Colour'),
+                    'type' => 'singleline',
+                    'class' => 'code'
+                ),
+                'default' => array(
+                    'heading' => Craft::t('buttonbox', 'Default?'),
+                    'type' => 'checkbox',
+                    'class' => 'thin'
+                ),
+            ),
+            'rows' => $options
         ));
 
     }
@@ -198,7 +202,7 @@ class Colours extends BaseOptionsField
      *
      * @return string The input HTML.
      */
-    public function getInputHtml($value, ElementInterface $element = null): string
+    public function getInputHtml(mixed $value, ?\craft\base\ElementInterface $element = null): string
     {
         $name = $this->handle;
         $options = $this->translatedOptions();

--- a/src/fields/Stars.php
+++ b/src/fields/Stars.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ButtonBox plugin for Craft CMS 3.x
+ * ButtonBox plugin for Craft CMS 4.x
  *
  * ButtonBox
  *
@@ -59,7 +59,7 @@ class Stars extends Field
      *
      * @return array
      */
-    public function rules()
+    public function rules(): array
     {
         $rules = parent::rules();
         $rules = array_merge($rules, [
@@ -72,7 +72,7 @@ class Stars extends Field
     /**
      * Returns the column type that this field should get within the content table.
      */
-    public function getContentColumnType(): string
+    public function getContentColumnType(): array|string
     {
         return Schema::TYPE_INTEGER;
     }
@@ -90,7 +90,7 @@ class Stars extends Field
      *
      * @return mixed The prepared field value
      */
-    public function normalizeValue($value, ElementInterface $element = null)
+    public function normalizeValue(mixed $value, ?\craft\base\ElementInterface $element = null): mixed
     {
         return $value;
     }
@@ -107,7 +107,7 @@ class Stars extends Field
      *
      * @return null|false `false` in the event that the method is sure that no elements are going to be found.
      */
-    public function serializeValue($value, ElementInterface $element = null)
+    public function serializeValue(mixed $value, ?\craft\base\ElementInterface $element = null): mixed
     {
         return parent::serializeValue($value, $element);
     }
@@ -117,7 +117,7 @@ class Stars extends Field
      *
      * @return string|null
      */
-    public function getSettingsHtml()
+    public function getSettingsHtml(): ?string
     {
         // Render the settings template
         return Craft::$app->getView()->renderTemplate(
@@ -135,7 +135,7 @@ class Stars extends Field
      *
      * @return string The input HTML.
      */
-    public function getInputHtml($value, ElementInterface $element = null): string
+    public function getInputHtml(mixed $value, ?\craft\base\ElementInterface $element = null): string
     {
         $name = $this->handle;
 

--- a/src/fields/TextSize.php
+++ b/src/fields/TextSize.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ButtonBox plugin for Craft CMS 3.x
+ * ButtonBox plugin for Craft CMS 4.x
  *
  * ButtonBox
  *
@@ -10,6 +10,7 @@
 
 namespace verbb\buttonbox\fields;
 
+use craft\helpers\Cp;
 use verbb\buttonbox\ButtonBox as ButtonBoxPlugin;
 use verbb\buttonbox\assetbundles\buttonbox\ButtonBoxAsset;
 
@@ -39,7 +40,7 @@ class TextSize extends BaseOptionsField
     // Static Methods
     // =========================================================================
     
-    public $options;
+    public array $options;
 
     /**
      * Returns the display name of this class.
@@ -59,7 +60,7 @@ class TextSize extends BaseOptionsField
      *
      * @return array
      */
-    public function rules()
+    public function rules(): array
     {
         $rules = parent::rules();
         return $rules;
@@ -86,7 +87,7 @@ class TextSize extends BaseOptionsField
      *
      * @return mixed The prepared field value
      */
-    public function normalizeValue($value, ElementInterface $element = null)
+    public function normalizeValue(mixed $value, ?\craft\base\ElementInterface $element = null): mixed
     {
         if ( !$value )
         {
@@ -101,7 +102,7 @@ class TextSize extends BaseOptionsField
         $selectedValues = (array)$value;
 
         $value = reset($selectedValues) ?: null;
-        $label = $this->optionLabel($value);
+        $label = $this->optionsSettingLabel();
         $value = new SingleOptionFieldData($label, $value, true);
 
         $options = [];
@@ -130,7 +131,7 @@ class TextSize extends BaseOptionsField
      *
      * @return null|false `false` in the event that the method is sure that no elements are going to be found.
      */
-    public function serializeValue($value, ElementInterface $element = null)
+    public function serializeValue(mixed $value, ?\craft\base\ElementInterface $element = null): mixed
     {
         return parent::serializeValue($value, $element);
     }
@@ -140,7 +141,7 @@ class TextSize extends BaseOptionsField
      *
      * @return string|null
      */
-    public function getSettingsHtml()
+    public function getSettingsHtml(): ?string
     {
         $options = $this->translatedOptions();
 
@@ -156,36 +157,37 @@ class TextSize extends BaseOptionsField
             );
         }
 
-        return Craft::$app->getView()->renderTemplateMacro('_includes/forms', 'editableTableField', array(
-            array(
-                'label'        => $this->optionsSettingLabel(),
-                'instructions' => Craft::t('buttonbox', 'Pixel Size is optional and should be a single number.'),
-                'id'           => 'options',
-                'name'         => 'options',
-                'addRowLabel'  => Craft::t('buttonbox', 'Add an option'),
-                'cols'         => array(
-                    'label' => array(
-                        'heading'      => Craft::t('buttonbox', 'Option Label'),
-                        'type'         => 'singleline',
-                        'autopopulate' => 'value'
-                    ),
-                    'value' => array(
-                        'heading'      => Craft::t('buttonbox', 'Value'),
-                        'type'         => 'singleline',
-                        'class'        => 'code'
-                    ),
-                    'pxVal' => array(
-                        'heading'      => Craft::t('buttonbox', 'Pixel Size'),
-                        'type'         => 'number'
-                    ),
-                    'default' => array(
-                        'heading'      => Craft::t('buttonbox', 'Default?'),
-                        'type'         => 'checkbox',
-                        'class'        => 'thin'
-                    ),
+        return Cp::editableTableFieldHtml(array(
+            'label' => $this->optionsSettingLabel(),
+            'instructions' => Craft::t('buttonbox', 'Pixel Size is optional and should be a single number.'),
+            'id' => 'options',
+            'name' => 'options',
+            'addRowLabel' => Craft::t('buttonbox', 'Add an option'),
+            'allowAdd' => true,
+            'allowReorder' => true,
+            'allowDelete' => true,
+            'cols' => array(
+                'label' => array(
+                    'heading' => Craft::t('buttonbox', 'Option Label'),
+                    'type' => 'singleline',
+                    'autopopulate' => 'value'
                 ),
-                'rows' => $options
-            )
+                'value' => array(
+                    'heading' => Craft::t('buttonbox', 'Value'),
+                    'type' => 'singleline',
+                    'class' => 'code'
+                ),
+                'pxVal' => array(
+                    'heading' => Craft::t('buttonbox', 'Pixel Size'),
+                    'type' => 'number'
+                ),
+                'default' => array(
+                    'heading' => Craft::t('buttonbox', 'Default?'),
+                    'type' => 'checkbox',
+                    'class' => 'thin'
+                ),
+            ),
+            'rows' => $options
         ));
 
     }
@@ -197,7 +199,7 @@ class TextSize extends BaseOptionsField
      *
      * @return string The input HTML.
      */
-    public function getInputHtml($value, ElementInterface $element = null): string
+    public function getInputHtml(mixed $value, ?\craft\base\ElementInterface $element = null): string
     {
         $name = $this->handle;
         $options = $this->translatedOptions();
@@ -229,10 +231,10 @@ class TextSize extends BaseOptionsField
 
     /**
      * Override this method to return custom default value
-     * 
-     * @return string 
+     *
+     * @return array|string|null
      */
-    protected function defaultValue()
+    protected function defaultValue(): array|string|null
     {
 
         $options = $this->translatedOptions();

--- a/src/fields/Triggers.php
+++ b/src/fields/Triggers.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ButtonBox plugin for Craft CMS 3.x
+ * ButtonBox plugin for Craft CMS 4.x
  *
  * ButtonBox
  *
@@ -10,6 +10,7 @@
 
 namespace verbb\buttonbox\fields;
 
+use craft\helpers\Cp;
 use verbb\buttonbox\ButtonBox as ButtonBoxPlugin;
 use verbb\buttonbox\assetbundles\buttonbox\ButtonBoxAsset;
 
@@ -37,7 +38,7 @@ class Triggers extends BaseOptionsField
     // Static Methods
     // =========================================================================
     
-    public $options;
+    public array $options;
     public $displayAsGraphic;
     public $displayFullwidth;
 
@@ -69,7 +70,7 @@ class Triggers extends BaseOptionsField
      *
      * @return string|null
      */
-    public function getSettingsHtml()
+    public function getSettingsHtml(): ?string
     {
         $options = $this->translatedOptions();
 
@@ -88,73 +89,70 @@ class Triggers extends BaseOptionsField
             );
         }
 
-        $table =  Craft::$app->getView()->renderTemplateMacro('_includes/forms', 'editableTableField', array(
-            array(
-                'label'        => $this->optionsSettingLabel(),
-                'instructions' => Craft::t('buttonbox', 'Image urls can be relative e.g. /admin/resources/buttonbox/images/align-left.png'),
-                'id'           => 'options',
-                'name'         => 'options',
-                'addRowLabel'  => Craft::t('buttonbox', 'Add a trigger'),
-                'cols'         => array(
-                  'label' => array(
-                    'heading'      => Craft::t('buttonbox', 'Option Label'),
-                    'type'         => 'singleline'
-                    ),
-                  'showLabel' => array(
-                    'heading'      => Craft::t('buttonbox', 'Show Label?'),
-                    'type'         => 'checkbox',
-                    'class'        => 'thin'
-                    ),
-                  'imageUrl' => array(
-                    'heading'      => Craft::t('buttonbox', 'Image URL'),
-                    'type'         => 'singleline'
-                    ),
-                  'type' => array(
+        $table = Cp::editableTableFieldHtml(array(
+            'label' => $this->optionsSettingLabel(),
+            'instructions' => Craft::t('buttonbox', 'Image urls can be relative e.g. /admin/resources/buttonbox/images/align-left.png'),
+            'id' => 'options',
+            'name' => 'options',
+            'addRowLabel' => Craft::t('buttonbox', 'Add a trigger'),
+            'allowAdd' => true,
+            'allowReorder' => true,
+            'allowDelete' => true,
+            'cols' => array(
+                'label' => array(
+                    'heading' => Craft::t('buttonbox', 'Option Label'),
+                    'type' => 'singleline'
+                ),
+                'showLabel' => array(
+                    'heading' => Craft::t('buttonbox', 'Show Label?'),
+                    'type' => 'checkbox',
+                    'class' => 'thin'
+                ),
+                'imageUrl' => array(
+                    'heading' => Craft::t('buttonbox', 'Image URL'),
+                    'type' => 'singleline'
+                ),
+                'type' => array(
                     'heading' => Craft::t('buttonbox', 'Trigger Type'),
-                    'class'   => 'thin triggerType',
-                    'type'    => 'select',
+                    'class' => 'thin triggerType',
+                    'type' => 'select',
                     'options' => array(
-                      'link' => 'Link',
-                      'js'   => 'JavaScript'
-                      ),
+                        'link' => 'Link',
+                        'js' => 'JavaScript'
                     ),
-                  'value' => array(
-                    'heading'      => Craft::t('buttonbox', 'HREF or Custom JS'),
-                    'type'         => 'singleline',
-                    'class'        => 'code triggerValue'
-                    ),
-                  'newWindow' => array(
-                    'heading'      => Craft::t('buttonbox', 'New window?'),
-                    'type'         => 'checkbox',
-                    'class'        => 'thin newWindow'
-                    ),
-                  ),
-                'rows' => $options
-            )
+                ),
+                'value' => array(
+                    'heading' => Craft::t('buttonbox', 'HREF or Custom JS'),
+                    'type' => 'singleline',
+                    'class' => 'code triggerValue'
+                ),
+                'newWindow' => array(
+                    'heading' => Craft::t('buttonbox', 'New window?'),
+                    'type' => 'checkbox',
+                    'class' => 'thin newWindow'
+                ),
+            ),
+            'rows' => $options
         ));
 
-        $displayAsGraphic = Craft::$app->getView()->renderTemplateMacro('_includes/forms', 'checkboxField', array(
-          array(
-            'label' => Craft::t('buttonbox', 'Display as graphic'),
+        $displayAsGraphic = Cp::checkboxFieldHtml(array(
+            'checkboxLabel' => Craft::t('buttonbox', 'Display as graphic'),
             'instructions' => Craft::t('buttonbox', 'This will take the height restrictions off the buttons to allow for larger images.'),
             'id' => 'displayAsGraphic',
             'name' => 'displayAsGraphic',
             'class' => 'displayAsGraphic',
             'value' => 1,
             'checked' => $this->displayAsGraphic
-            )
         ));
 
-        $displayFullwidth = Craft::$app->getView()->renderTemplateMacro('_includes/forms', 'checkboxField', array(
-          array(
-            'label' => Craft::t('buttonbox', 'Display full width'),
+        $displayFullwidth = Cp::checkboxFieldHtml(array(
+            'checkboxLabel' => Craft::t('buttonbox', 'Display full width'),
             'instructions' => Craft::t('buttonbox', 'Allow the button group to be fullwidth, useful for allowing larger graphics to be more responsive.'),
             'id' => 'displayFullwidth',
             'name' => 'displayFullwidth',
             'class' => 'displayFullwidth',
             'value' => 1,
             'checked' => $this->displayFullwidth
-            )
         ));
 
         return $displayAsGraphic . $displayFullwidth . $table;
@@ -168,7 +166,7 @@ class Triggers extends BaseOptionsField
      *
      * @return string The input HTML.
      */
-    public function getInputHtml($value, ElementInterface $element = null): string
+    public function getInputHtml(mixed $value, ?\craft\base\ElementInterface $element = null): string
     {
         $name = $this->handle;
         $options = $this->translatedOptions();

--- a/src/fields/Width.php
+++ b/src/fields/Width.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ButtonBox plugin for Craft CMS 3.x
+ * ButtonBox plugin for Craft CMS 4.x
  *
  * ButtonBox
  *
@@ -10,6 +10,7 @@
 
 namespace verbb\buttonbox\fields;
 
+use craft\helpers\Cp;
 use verbb\buttonbox\ButtonBox as ButtonBoxPlugin;
 use verbb\buttonbox\assetbundles\buttonbox\ButtonBoxAsset;
 
@@ -39,7 +40,7 @@ class Width extends BaseOptionsField
     // Static Methods
     // =========================================================================
     
-    public $options;
+    public array $options;
 
     /**
      * Returns the display name of this class.
@@ -59,7 +60,7 @@ class Width extends BaseOptionsField
      *
      * @return array
      */
-    public function rules()
+    public function rules(): array
     {
         $rules = parent::rules();
         return $rules;
@@ -86,7 +87,7 @@ class Width extends BaseOptionsField
      *
      * @return mixed The prepared field value
      */
-    public function normalizeValue($value, ElementInterface $element = null)
+    public function normalizeValue(mixed $value, ?\craft\base\ElementInterface $element = null): mixed
     {
         if ( !$value )
         {
@@ -101,7 +102,7 @@ class Width extends BaseOptionsField
         $selectedValues = (array)$value;
 
         $value = reset($selectedValues) ?: null;
-        $label = $this->optionLabel($value);
+        $label = $this->optionsSettingLabel();
         $value = new SingleOptionFieldData($label, $value, true);
 
         $options = [];
@@ -130,7 +131,7 @@ class Width extends BaseOptionsField
      *
      * @return null|false `false` in the event that the method is sure that no elements are going to be found.
      */
-    public function serializeValue($value, ElementInterface $element = null)
+    public function serializeValue(mixed $value, ?\craft\base\ElementInterface $element = null): mixed
     {
         return parent::serializeValue($value, $element);
     }
@@ -140,7 +141,7 @@ class Width extends BaseOptionsField
      *
      * @return string|null
      */
-    public function getSettingsHtml()
+    public function getSettingsHtml(): ?string
     {
         $options = $this->translatedOptions();
 
@@ -155,32 +156,33 @@ class Width extends BaseOptionsField
             );
         }
 
-        return Craft::$app->getView()->renderTemplateMacro('_includes/forms', 'editableTableField', array(
-            array(
-                'label'        => $this->optionsSettingLabel(),
-                'instructions' => Craft::t('buttonbox', 'Define the available options.'),
-                'id'           => 'options',
-                'name'         => 'options',
-                'addRowLabel'  => Craft::t('buttonbox', 'Add an option'),
-                'cols'         => array(
-                    'label' => array(
-                        'heading'      => Craft::t('buttonbox', 'Option Label'),
-                        'type'         => 'singleline',
-                        'autopopulate' => 'value'
-                    ),
-                    'value' => array(
-                        'heading'      => Craft::t('buttonbox', 'Value'),
-                        'type'         => 'singleline',
-                        'class'        => 'code'
-                    ),
-                    'default' => array(
-                        'heading'      => Craft::t('buttonbox', 'Default?'),
-                        'type'         => 'checkbox',
-                        'class'        => 'thin'
-                    ),
+        return Cp::editableTableFieldHtml(array(
+            'label' => $this->optionsSettingLabel(),
+            'instructions' => Craft::t('buttonbox', 'Define the available options.'),
+            'id' => 'options',
+            'name' => 'options',
+            'addRowLabel' => Craft::t('buttonbox', 'Add an option'),
+            'allowAdd' => true,
+            'allowReorder' => true,
+            'allowDelete' => true,
+            'cols' => array(
+                'label' => array(
+                    'heading' => Craft::t('buttonbox', 'Option Label'),
+                    'type' => 'singleline',
+                    'autopopulate' => 'value'
                 ),
-                'rows' => $options
-            )
+                'value' => array(
+                    'heading' => Craft::t('buttonbox', 'Value'),
+                    'type' => 'singleline',
+                    'class' => 'code'
+                ),
+                'default' => array(
+                    'heading' => Craft::t('buttonbox', 'Default?'),
+                    'type' => 'checkbox',
+                    'class' => 'thin'
+                ),
+            ),
+            'rows' => $options
         ));
 
     }
@@ -192,7 +194,7 @@ class Width extends BaseOptionsField
      *
      * @return string The input HTML.
      */
-    public function getInputHtml($value, ElementInterface $element = null): string
+    public function getInputHtml(mixed $value, ?\craft\base\ElementInterface $element = null): string
     {
         $name = $this->handle;
         $options = $this->translatedOptions();
@@ -225,9 +227,9 @@ class Width extends BaseOptionsField
     /**
      * Override this method to return custom default value
      * 
-     * @return string 
+     * @return array|string|null
      */
-    protected function defaultValue()
+    protected function defaultValue(): array|string|null
     {
 
         $options = $this->translatedOptions();

--- a/src/templates/_components/fields/colours/input.twig
+++ b/src/templates/_components/fields/colours/input.twig
@@ -12,7 +12,7 @@
     {% endfor %}
   </select>
 
-  {% spaceless %}
+  {% apply spaceless %}
   {% for key, option in options %}
     {% set optionLabel = (option.label is defined ? option.label : option) %}
     {% set optionValue = (option.value is defined ? option.value : key) %}
@@ -24,7 +24,7 @@
       </a>
     {% endif %}
   {% endfor %}
-  {% endspaceless %}
+  {% endapply %}
 
   <div class="menu  buttonbox-fancyoptions-menu" data-align="right">
     <ul class="padded">

--- a/src/templates/_components/fields/textsize/input.twig
+++ b/src/templates/_components/fields/textsize/input.twig
@@ -13,7 +13,7 @@
     {% endfor %}
   </select>
 
-  {% spaceless %}
+  {% apply spaceless %}
   {% for key, option in options %}
     {% set optionLabel = (option.label is defined ? option.label : option) %}
     {% set optionValue = (option.value is defined ? option.value : key) %}
@@ -23,7 +23,7 @@
       </a>
     {% endif %}
   {% endfor %}
-  {% endspaceless %}
+  {% endapply %}
 
 
   <div class="menu  buttonbox-fancyoptions-menu" data-align="right">


### PR DESCRIPTION
- Adds required types
- Replaces deprecated methods

**Note:** For some reason the image icon paths are not working, but all fields are usable and return the expected output.